### PR TITLE
OTPS error tar

### DIFF
--- a/otps.rb
+++ b/otps.rb
@@ -16,7 +16,7 @@ class Otps < Formula
   def install
     system "pwd" 
     system "ls", "-a"
-    system "tar", "xvzf", "OTPS2.tar.Z"
+    system "tar", "xvzf", "OTPS--2.tar.Z"
     system "cd", "OTPS2"
     system "ls", "-a"
     system "make", "extract_HC"


### PR DESCRIPTION
ran: brew install dwcaress/mbsystem/otps --with-tpxo8
error: tar: Error opening archive: Failed to open 'OTPS2.tar.Z'

I believe this is because the folder being opened located here /User/library/caches/homebrew/OTPS--2.tar.Z
I can unzip it manually in this location and see the items drawn upon e.g. Extract_HC

The folder ***--OTPS2.tar.Z ends up in /User/library/caches/homebrew/downloads

Has anyone else had this problem when trying to install?